### PR TITLE
Fix bug with multi level objects

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,8 +55,9 @@ function objectToString(object, prefix) {
         }
         else {
             acc += subKey + '=' + value;
+            acc += ' ';
         }
-        acc += ' ';
+        
         return acc;
     }, '');
 }


### PR DESCRIPTION
This fixes an issue with multi level object:
```
var stats = {
    "Data": {
        "common": {
            "last_incr_ts": 1611853135,
            "last_incr_ts_timespan_seconds": 0,
            "start_ts": 1611853041,
            "start_ts_timespan_seconds": 94,
            "status_code": 0
        },
        "minute": {
            "nsq_messages_processed_per_message_type_8": 1106,
            "nsq_messages_seen": 1106,
            "tracking_messages": 1106,
            "tracking_messages1": 1106,
            "tracking_messages2": 1106,
            "tracking_messages3": 1106,
        }
    },
    "Message": "",
    "Response": "Success",
    "Type": 100
};
```
Before change:

```
'
Data.common.last_incr_ts=1611853135 
Data.common.last_incr_ts_timespan_seconds=0 
Data.common.start_ts=1611853041 
Data.common.start_ts_timespan_seconds=94 
Data.common.status_code=0 
 Data.minute.nsq_messages_processed_per_message_type_8=1106 
Data.minute.nsq_messages_seen=1106 
Data.minute.tracking_messages=1106 
Data.minute.tracking_messages1=1106 
Data.minute.tracking_messages2=1106 
Data.minute.tracking_messages3=1106 
  Message= Response=Success 
Type=100 
'
```

After change:
```
'
Data.common.last_incr_ts=1611853135 
Data.common.last_incr_ts_timespan_seconds=0 
Data.common.start_ts=1611853041 
Data.common.start_ts_timespan_seconds=94 
Data.common.status_code=0 
Data.minute.nsq_messages_processed_per_message_type_8=1106 
Data.minute.nsq_messages_seen=1106 
Data.minute.tracking_messages=1106 
Data.minute.tracking_messages1=1106 
Data.minute.tracking_messages2=1106 
Data.minute.tracking_messages3=1106 
Message= 
Response=Success 
Type=100 
'
```